### PR TITLE
fix uninitialized constant Ever2boost::EvernoteAuthorizer::FileUtils when import

### DIFF
--- a/lib/ever2boost/util.rb
+++ b/lib/ever2boost/util.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Ever2boost
   class Util
     class << self


### PR DESCRIPTION
https://github.com/BoostIO/ever2boost/issues/7
https://github.com/BoostIO/ever2boost/issues/10